### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/joshbacule/b7fd75c6-f1c2-47d5-9c57-7c74aa240c54/c66c0cfa-bb26-4281-9a5a-12b3cbe689fb/_apis/work/boardbadge/6b39b7fb-f87b-4282-bead-bb1babc0880e)](https://dev.azure.com/joshbacule/b7fd75c6-f1c2-47d5-9c57-7c74aa240c54/_boards/board/t/c66c0cfa-bb26-4281-9a5a-12b3cbe689fb/Microsoft.RequirementCategory)
 # amz-chrome-bot
 A mini-bot extension that navigates & get data from Seller Central and Amazon website.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/joshbacule/b7fd75c6-f1c2-47d5-9c57-7c74aa240c54/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.